### PR TITLE
 Fix incorrect main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@shortercode/webzip",
   "version": "1.1.0",
   "description": "A modern TypeScript library for creating, reading and editing ZIP archives in a client side environment.",
-  "main": "cjs/index.js",
+  "main": "index.js",
   "module": "mjs/index.mjs",
   "types": "mjs/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.1.0",
   "description": "A modern TypeScript library for creating, reading and editing ZIP archives in a client side environment.",
   "main": "index.js",
-  "module": "mjs/index.mjs",
-  "types": "mjs/index.d.ts",
+  "module": "index.mjs",
+  "types": "index.d.ts",
   "scripts": {
     "test": "jest --verbose --coverage",
     "typecheck": "tsc --noEmit --watch",


### PR DESCRIPTION
Fix for:
(node:21314) [DEP0128] DeprecationWarning: Invalid 'main' field in ..../node_modules/@shortercode/webzip/package.json' of 'cjs/index.js'. Please either fix that or report it to the module author"

Otherwise no execution is possible 

@shortercode Would be nice if you could merge it