### PR TITLE
Working jest test with typescript

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    transform: {
+      '^.+\\.ts?$': ['ts-jest', { tsconfig: './tsconfig.jest.json' }],
+    },
+    testRegex: '/test/.*\\.test?\\.ts$',
+    moduleFileExtensions: ['ts', 'js'],
+  };

--- a/test/crc.test.ts
+++ b/test/crc.test.ts
@@ -1,0 +1,17 @@
+import {expect, test} from '@jest/globals';
+
+import { crc32 } from "../src/crc32";
+
+describe('crc module', () => {
+	test('crc for a simple string is correct', async () => {
+		const something = "something";
+		var blob = new Blob([something], {
+			type: 'text/plain'
+		});
+
+		const buffer = await new Response(blob).arrayBuffer();
+		const bytes = new Uint8Array(buffer);
+
+		expect(crc32(bytes)).toBe(0x9DA31FB);
+	});
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "verbatimModuleSyntax": false
+    }
+  }


### PR DESCRIPTION
Adds a simple test that calls into crc32 and adds configs to make testing in typescript work with jest